### PR TITLE
添加数据库集成（MongoDB和MySQL）

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,20 @@
+# 环境变量
+NODE_ENV=development
+PORT=3000
+
+# MongoDB配置
+MONGODB_URI=mongodb://localhost:27017/yd-mcp-app
+
+# MySQL配置
+MYSQL_DATABASE=yd_mcp_app
+MYSQL_USERNAME=root
+MYSQL_PASSWORD=password
+MYSQL_HOST=localhost
+MYSQL_PORT=3306
+
+# 其他配置
+SECRET_KEY=your-secret-key-for-jwt
+API_PREFIX=/api
+
+# 日志级别
+LOG_LEVEL=info

--- a/config/database.js
+++ b/config/database.js
@@ -1,0 +1,28 @@
+require('dotenv').config();
+
+module.exports = {
+  // MongoDB配置
+  mongodb: {
+    uri: process.env.MONGODB_URI || 'mongodb://localhost:27017/yd-mcp-app',
+    options: {
+      useNewUrlParser: true,
+      useUnifiedTopology: true,
+    }
+  },
+  
+  // MySQL配置
+  mysql: {
+    database: process.env.MYSQL_DATABASE || 'yd_mcp_app',
+    username: process.env.MYSQL_USERNAME || 'root',
+    password: process.env.MYSQL_PASSWORD || 'password',
+    host: process.env.MYSQL_HOST || 'localhost',
+    port: process.env.MYSQL_PORT || 3306,
+    dialect: 'mysql',
+    pool: {
+      max: 5,
+      min: 0,
+      acquire: 30000,
+      idle: 10000
+    }
+  }
+};

--- a/db/mongoose.js
+++ b/db/mongoose.js
@@ -1,0 +1,15 @@
+const mongoose = require('mongoose');
+const config = require('../config/database').mongodb;
+
+// 连接MongoDB
+const connectMongoDB = async () => {
+  try {
+    await mongoose.connect(config.uri, config.options);
+    console.log('MongoDB连接成功');
+  } catch (error) {
+    console.error('MongoDB连接失败:', error.message);
+    process.exit(1);
+  }
+};
+
+module.exports = connectMongoDB;

--- a/db/sequelize.js
+++ b/db/sequelize.js
@@ -1,0 +1,18 @@
+const db = require('../models');
+
+// 连接MySQL
+const connectMySQL = async () => {
+  try {
+    await db.sequelize.authenticate();
+    console.log('MySQL连接成功');
+    
+    // 同步模型到数据库 (开发环境可以使用)
+    // await db.sequelize.sync({ force: true });
+    // console.log('所有模型已重新同步');
+  } catch (error) {
+    console.error('MySQL连接失败:', error.message);
+    process.exit(1);
+  }
+};
+
+module.exports = connectMySQL;

--- a/models/index.js
+++ b/models/index.js
@@ -1,0 +1,27 @@
+const { Sequelize } = require('sequelize');
+const dbConfig = require('../config/database').mysql;
+
+// 初始Sequelize实例
+const sequelize = new Sequelize(
+  dbConfig.database,
+  dbConfig.username,
+  dbConfig.password,
+  {
+    host: dbConfig.host,
+    dialect: dbConfig.dialect,
+    port: dbConfig.port,
+    pool: dbConfig.pool,
+    logging: console.log
+  }
+);
+
+// 模型对象
+const db = {};
+
+db.Sequelize = Sequelize;
+db.sequelize = sequelize;
+
+// 导入模型
+db.User = require('./user.model')(sequelize, Sequelize);
+
+module.exports = db;

--- a/models/user.model.js
+++ b/models/user.model.js
@@ -1,0 +1,43 @@
+module.exports = (sequelize, Sequelize) => {
+  const User = sequelize.define('user', {
+    id: {
+      type: Sequelize.INTEGER,
+      primaryKey: true,
+      autoIncrement: true
+    },
+    name: {
+      type: Sequelize.STRING,
+      allowNull: false
+    },
+    email: {
+      type: Sequelize.STRING,
+      allowNull: false,
+      unique: true,
+      validate: {
+        isEmail: true
+      }
+    },
+    password: {
+      type: Sequelize.STRING,
+      allowNull: false
+    },
+    status: {
+      type: Sequelize.ENUM('active', 'inactive'),
+      defaultValue: 'active'
+    },
+    role: {
+      type: Sequelize.ENUM('admin', 'user'),
+      defaultValue: 'user'
+    },
+    createdAt: {
+      type: Sequelize.DATE,
+      defaultValue: Sequelize.NOW
+    },
+    updatedAt: {
+      type: Sequelize.DATE,
+      defaultValue: Sequelize.NOW
+    }
+  });
+
+  return User;
+};

--- a/package.json
+++ b/package.json
@@ -2,24 +2,27 @@
   "name": "yd-mcp-app",
   "version": "1.0.0",
   "description": "YD MCP Application",
-  "main": "src/app.js",
+  "main": "app.js",
   "scripts": {
-    "start": "node src/app.js",
-    "dev": "nodemon src/app.js",
+    "start": "node app.js",
+    "dev": "nodemon app.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [
     "koa",
-    "nodejs",
     "api"
   ],
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "koa": "^2.14.2",
+    "dotenv": "^16.4.1",
+    "koa": "^2.15.0",
     "koa-bodyparser": "^4.4.1",
+    "koa-logger": "^3.2.1",
     "koa-router": "^12.0.1",
-    "koa-logger": "^3.2.1"
+    "mongoose": "^8.1.0",
+    "mysql2": "^3.9.1",
+    "sequelize": "^6.35.2"
   },
   "devDependencies": {
     "nodemon": "^3.0.3"

--- a/schema/user.schema.js
+++ b/schema/user.schema.js
@@ -1,0 +1,40 @@
+const mongoose = require('mongoose');
+const Schema = mongoose.Schema;
+
+const UserSchema = new Schema({
+  name: {
+    type: String,
+    required: true
+  },
+  email: {
+    type: String,
+    required: true,
+    unique: true,
+    lowercase: true,
+    trim: true
+  },
+  password: {
+    type: String,
+    required: true
+  },
+  status: {
+    type: String,
+    enum: ['active', 'inactive'],
+    default: 'active'
+  },
+  role: {
+    type: String,
+    enum: ['admin', 'user'],
+    default: 'user'
+  },
+  createdAt: {
+    type: Date,
+    default: Date.now
+  },
+  updatedAt: {
+    type: Date,
+    default: Date.now
+  }
+});
+
+module.exports = mongoose.model('User', UserSchema);


### PR DESCRIPTION
## 功能描述

这个PR添加了数据库集成支持，具体包括：

- MongoDB集成 (使用Mongoose)
- MySQL集成 (使用Sequelize ORM)
- 用户模型设计
- 数据库配置文件

## 实现内容

1. 添加了配置文件
2. 创建了数据库连接模块
3. 设计了用户模型
4. 添加了环境变量示例文件

## 如何测试

1. 复制 `.env.example` 为 `.env` 并修改数据库配置
2. 确保本地有MongoDB和MySQL服务运行
3. 运行应用程序并检查连接日志

## 待解决问题

- 数据库迁移策略尚未实现
- 事务处理还未集成
- 未添加关联关系模型